### PR TITLE
feat: solution 2 isPalinPerm

### DIFF
--- a/ArraysAndStrings/isPalinPerm/solution2.js
+++ b/ArraysAndStrings/isPalinPerm/solution2.js
@@ -1,0 +1,28 @@
+//function to check if there is a a palendrome in any permutation of string
+
+let yesP = 'qwertytrewq'
+let yesP2 = 'aabb'
+let emptyStr = ''
+let noP = 'qre'
+let space = 'tacca to'
+let ignoreNonLet = 'ta#$(3784cotac'
+
+//time O(n), space O(n)
+function palendromePermutation(str) {
+  if (str.length === 0) return -1
+  let spaceRegex = /\s/g
+  let nonAlphaRegex = /[^a-z]/gi
+  str = str.replace(spaceRegex, '').replace(nonAlphaRegex, '').toLowerCase()
+  let strSet = new Set(str)
+  if (strSet.size !== Math.ceil(str.length / 2)) return false
+  else return true
+}
+
+console.group('palendromePermutation quick tests')
+console.log(palendromePermutation(yesP)) //true
+console.log(palendromePermutation(yesP2)) //true
+console.log(palendromePermutation(emptyStr)) //-1
+console.log(palendromePermutation(noP)) // false
+console.log(palendromePermutation(space)) //true
+console.log(palendromePermutation(ignoreNonLet)) //true
+console.groupEnd()

--- a/ArraysAndStrings/isPalinPerm/solution2.js
+++ b/ArraysAndStrings/isPalinPerm/solution2.js
@@ -13,23 +13,21 @@ let tooManyRepeatsTrue = 'aaccc'
 //time O(n), space O(n)
 function palendromePermutation(str) {
   if (str.length === 0) return -1
-  let spaceRegex = /\s/g
-  let nonAlphaRegex = /[^a-z]/gi
-  str = str.replace(spaceRegex, '').replace(nonAlphaRegex, '').toLowerCase()
   let strHash = {}
-  for (let letter of str){
-      strHash[letter] ? strHash[letter]++ : strHash[letter] = 1
+  for (let letter of str) {
+    if (letter < 10 || letter.toLowerCase() === letter.toUpperCase()) continue
+    strHash[letter]
+      ? strHash[letter.toLowerCase()]++
+      : (strHash[letter.toLowerCase()] = 1)
   }
   endingValues = Object.values(strHash)
   let numOdd = 0
-  for (let item of endingValues){
-      if (item % 2 !== 0) numOdd++
-      if (numOdd > 1) return false
+  for (let item of endingValues) {
+    if (item % 2 !== 0) numOdd++
+    if (numOdd > 1) return false
   }
   return true
 }
-
-
 
 console.group('palendromePermutation quick tests')
 console.log(palendromePermutation(yesP)) //true

--- a/ArraysAndStrings/isPalinPerm/solution2.js
+++ b/ArraysAndStrings/isPalinPerm/solution2.js
@@ -1,4 +1,5 @@
 //function to check if there is a a palendrome in any permutation of string
+//ignore non-alpha char and spaces
 
 let yesP = 'qwertytrewq'
 let yesP2 = 'aabb'
@@ -6,6 +7,8 @@ let emptyStr = ''
 let noP = 'qre'
 let space = 'tacca to'
 let ignoreNonLet = 'ta#$(3784cotac'
+let tooManyRepeats = 'aaac'
+let tooManyRepeatsTrue = 'aaccc'
 
 //time O(n), space O(n)
 function palendromePermutation(str) {
@@ -13,10 +16,20 @@ function palendromePermutation(str) {
   let spaceRegex = /\s/g
   let nonAlphaRegex = /[^a-z]/gi
   str = str.replace(spaceRegex, '').replace(nonAlphaRegex, '').toLowerCase()
-  let strSet = new Set(str)
-  if (strSet.size !== Math.ceil(str.length / 2)) return false
-  else return true
+  let strHash = {}
+  for (let letter of str){
+      strHash[letter] ? strHash[letter]++ : strHash[letter] = 1
+  }
+  endingValues = Object.values(strHash)
+  let numOdd = 0
+  for (let item of endingValues){
+      if (item % 2 !== 0) numOdd++
+      if (numOdd > 1) return false
+  }
+  return true
 }
+
+
 
 console.group('palendromePermutation quick tests')
 console.log(palendromePermutation(yesP)) //true
@@ -25,4 +38,6 @@ console.log(palendromePermutation(emptyStr)) //-1
 console.log(palendromePermutation(noP)) // false
 console.log(palendromePermutation(space)) //true
 console.log(palendromePermutation(ignoreNonLet)) //true
+console.log(palendromePermutation(tooManyRepeats)) //false
+console.log(palendromePermutation(tooManyRepeatsTrue)) //true
 console.groupEnd()


### PR DESCRIPTION
This pull request adds an alternate solution to the 1.4 Palindrome Permutation. It uses regex and set functionality to to functionally program the numeric results required. The two regex matches are used to remove spaces and non-alpha characters since they don't affect the results. A string will have a permutation that is a palindrome if when you take out the copies, it has exactly half or one more than half the number of characters as before. new Set() takes out copies quickly. 

Let me know if there are problems with it for me to fix!